### PR TITLE
feat: create status page and add real-time info with database metrics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "node-pg-migrate": "7.6.1",
         "pg": "8.12.0",
         "react": "18.3.1",
-        "react-dom": "18.3.1"
+        "react-dom": "18.3.1",
+        "swr": "2.2.5"
       },
       "devDependencies": {
         "@commitlint/cli": "19.4.0",
@@ -11127,6 +11128,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swr": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.2.5.tgz",
+      "integrity": "sha512-QtxqyclFeAsxEUeZIYmsaQ0UjimSq1RZ9Un7I68/0ClKK/U3LoyQunwkQfJZr2fc22DfIXLNDc2wFyTEikCUpg==",
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "^0.0.1",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/synckit": {
       "version": "0.8.8",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.8.tgz",
@@ -11586,6 +11600,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "node-pg-migrate": "7.6.1",
     "pg": "8.12.0",
     "react": "18.3.1",
-    "react-dom": "18.3.1"
+    "react-dom": "18.3.1",
+    "swr": "2.2.5"
   },
   "devDependencies": {
     "@commitlint/cli": "19.4.0",

--- a/pages/status/index.js
+++ b/pages/status/index.js
@@ -1,0 +1,66 @@
+import useSWR from "swr";
+
+const fetchAPI = async (key) => {
+  const response = await fetch(key);
+
+  const responseBody = await response.json();
+
+  return responseBody;
+};
+
+export default function StatusPage() {
+  const { isLoading, data } = useSWR("/api/v1/status", fetchAPI, {
+    refreshInterval: 2000,
+  });
+
+  const database = data?.dependencies?.database;
+
+  return (
+    <>
+      <h1>Status</h1>
+      <UpdatedAt isLoading={isLoading} updatedAt={data?.updated_at} />
+      <MaxConnections isLoading={isLoading} max={database?.max_connections} />
+      <OpenedConnections
+        isLoading={isLoading}
+        opened={database?.opened_connections}
+      />
+      <Version isLoading={isLoading} version={database?.version} />
+    </>
+  );
+}
+
+function UpdatedAt({ isLoading, updatedAt }) {
+  const formattedDate = new Date(updatedAt).toLocaleString("pt-BR");
+
+  return (
+    <div>
+      <p>Última atualização: {isLoading ? "Carregando..." : formattedDate} </p>
+    </div>
+  );
+}
+
+function MaxConnections({ isLoading, max }) {
+  return (
+    <div>
+      <p>Número máximo de conexões: {isLoading ? "Carregando..." : max}</p>
+    </div>
+  );
+}
+
+function OpenedConnections({ isLoading, opened }) {
+  return (
+    <div>
+      <p>
+        Quantidade de conexões abertas: {isLoading ? "Carregando..." : opened}
+      </p>
+    </div>
+  );
+}
+
+function Version({ isLoading, version }) {
+  return (
+    <div>
+      <p>Versão: {isLoading ? "Carregando..." : version}</p>
+    </div>
+  );
+}


### PR DESCRIPTION
- Cria a página de `status` no front end
- Instala o pacote `swr` a aplicação
- Integra as informações do endpoint `api/v1/status` ao front end